### PR TITLE
Feature/beams

### DIFF
--- a/hardware/box.py
+++ b/hardware/box.py
@@ -18,7 +18,7 @@ from .dispenser import Dispenser
 from .beam import Beam 
 from .output import Output'''
 import os
-from hardware.components import Button, Lever, Door, ButtonManager, Dispenser
+from hardware.components import Button, Lever, Door, ButtonManager, Dispenser, Beam
 from hardware.timing import Phase, TimestampManager
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
@@ -34,6 +34,7 @@ COMPONENT_LOOKUP = {
                     'levers':{'component_class':Lever, 'label':'lever'},
                     'buttons':{'component_class':ButtonManager.new_button, 'label':'button'},
                     'dispenser':{'component_class':Dispenser, 'label':'dispenser'},
+                    'beams':{'component_class':Beam, 'label':'beam'},
                     }
 
 

--- a/hardware/components.py
+++ b/hardware/components.py
@@ -471,8 +471,8 @@ class Beam:
                 while self.ir_sensor_button.pressed: # wait for sensor to be unblocked. 
                      
                     if self.box.done: # check that box has not finished running in this time 
-                        ts = self.timestamp_q.new_timestamp(f'{self.name} break detected at {latency.start_time}, and box set to done before led unblocked')
-                        ts.submit() 
+                        latency.event_descriptor = (f'{self.name} break detected, and box set to done before it was unblocked')
+                        latency.submit() 
                         return
 
                     time.sleep(0.05)

--- a/hardware/default.yaml
+++ b/hardware/default.yaml
@@ -59,3 +59,13 @@ dispensers:
     sensor_pin: 16
     pullup_pulldown: pullup
     dispense_timeout: 3
+  
+beams: 
+  ir_1:
+    pin: 12 
+    pullup_pulldown: pullup
+  ir_2: 
+    pin: 13
+    pullup_pulldown: pullup
+
+


### PR DESCRIPTION
Beam Class: 

The only function included at the moment is monitor_beam_breaks which is meant for continuous monitoring for any beam breaks. It records the latency of how long the beam is blocked for. If the box finishes running before the beam is unblocked, then it records the latency from the time of beam break detection to time that box finishes running. 

Each beam also keeps tally of total number of beam breaks detected. (So if we need to add a function that is something like monitor_for_n_beam_breaks, can do so easily) 

***functionality has not been well tested yet*** 
